### PR TITLE
fix: Actually include the UE binary

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -41,6 +41,7 @@ parts:
       --gNB \
       --build-lib "telnetsrv enbscope uescope nrscope" \
       -w USRP -t Ethernet \
+      --nrUE \
       --build-e2 --cmake-opt -DXAPP_MULTILANGUAGE=OFF \
       --noavx512 \
       --cmake-opt -DCMAKE_C_FLAGS="-Werror" --cmake-opt -DCMAKE_CXX_FLAGS="-Werror"


### PR DESCRIPTION
# Description

The original PR did not build the UE binary, so it was missing from the image. This is now tested to run properly with the charm under development.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
