### PR TITLE
feat: Apply patch to use getaddrinfo when connecting to rfsim

### DIFF
--- a/patches/getaddrinfo.patch
+++ b/patches/getaddrinfo.patch
@@ -1,0 +1,86 @@
+diff --git a/radio/rfsimulator/simulator.c b/radio/rfsimulator/simulator.c
+index 26feb13490..fcbc5ae4a9 100644
+--- a/radio/rfsimulator/simulator.c
++++ b/radio/rfsimulator/simulator.c
+@@ -29,6 +29,7 @@
+  */
+ 
+ #include <sys/socket.h>
++#include <sys/types.h>
+ #include <netinet/in.h>
+ #include <netinet/tcp.h>
+ #include <arpa/inet.h>
+@@ -40,6 +41,7 @@
+ #include <errno.h>
+ #include <sys/epoll.h>
+ #include <string.h>
++#include <netdb.h>
+ 
+ #include <common/utils/assertions.h>
+ #include <common/utils/LOG/log.h>
+@@ -585,25 +587,52 @@ static int startServer(openair0_device *device) {
+ static int startClient(openair0_device *device) {
+   rfsimulator_state_t *t = device->priv;
+   t->role = SIMU_ROLE_CLIENT;
+-  int sock;
+-  if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+-    LOG_E(HW, "socket(SOCK_STREAM) failed, errno(%d)\n", errno);
+-    return -1;
+-  }
+-  struct sockaddr_in addr = {.sin_family = AF_INET, .sin_port = htons(t->port), .sin_addr = {.s_addr = INADDR_ANY}};
+-  addr.sin_addr.s_addr = inet_addr(t->ip);
++  int sock, s;
++  struct addrinfo hints;
++  struct addrinfo *result, *rp;
++
++  char port[6];
++  snprintf(port, sizeof(port), "%d", t->port);
++
++  memset(&hints, 0, sizeof(hints));
++  hints.ai_family = AF_INET;
++  hints.ai_socktype = SOCK_STREAM;
++  hints.ai_flags = 0;
++  hints.ai_protocol = 0;
++
+   bool connected=false;
+ 
+   while(!connected) {
+     LOG_I(HW, "Trying to connect to %s:%d\n", t->ip, t->port);
+ 
+-    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+-      LOG_I(HW, "Connection to %s:%d established\n", t->ip, t->port);
+-      connected=true;
+-    }
+ 
+-    LOG_I(HW, "connect() to %s:%d failed, errno(%d)\n", t->ip, t->port, errno);
+-    sleep(1);
++    s = getaddrinfo(t->ip, port, &hints, &result);
++    if (s != 0) {
++      LOG_I(HW, "getaddrinfo: %s\n", gai_strerror(s));
++    } else {
++      for (rp = result; rp != NULL; rp = rp->ai_next) {
++        sock = socket(rp->ai_family, rp->ai_socktype,
++                     rp->ai_protocol);
++        if (sock == -1)
++          continue;
++
++        if (connect(sock, rp->ai_addr, rp->ai_addrlen) != -1) {
++          LOG_I(HW, "Connection to %s:%d established\n", t->ip, t->port);
++          connected=true;
++          break;
++        }
++
++        close(sock);
++      }
++
++      freeaddrinfo(result);
++
++      if (rp == NULL) {
++        LOG_I(HW, "connect() to %s:%d failed, errno(%d)\n", t->ip, t->port, errno);
++        fprintf(stderr, "Could not connect\n");
++        sleep(1);
++      }
++    }
+   }
+ 
+   if (setblocking(sock, notBlocking) == -1) {

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -32,6 +32,9 @@ parts:
       - g++-12
       - gcc-12
       - openssl
+    override-pull: |
+      craftctl default
+      git apply ${CRAFT_PROJECT_DIR}/patches/getaddrinfo.patch
     override-build: |
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12
       /bin/sh oaienv


### PR DESCRIPTION
# Description

The upstream code does not do any name resolution when connecting to the DU in rfsimulation mode. This change uses `getaddrinfo()` to properly do the resolution.

This patch will be submitted to upstream once it is properly tested.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
